### PR TITLE
Update to latest MSM version

### DIFF
--- a/auth.rb
+++ b/auth.rb
@@ -9,7 +9,7 @@ class EmailAuth
     {
       :g => 1,
       :auth_version => "2.0.0",
-      :client_version => "4.5.0",
+      :client_version => "4.5.2",
       :device_id => $settings.device_id,
       :device_model => $settings.device_model,
       :device_vendor => $settings.device_vendor,

--- a/auth.rb
+++ b/auth.rb
@@ -46,7 +46,10 @@ class EmailAuth
   #   "contentUrl": "https:...files.json"
   # }
   def self.pregame_setup(token)
-    post("https://msm-auth.bbbgame.net/pregame_setup.php", :body => common_params, :headers => {
+    params = {
+      :access_key => $settings.access_key
+    }
+    post("https://msm-auth.bbbgame.net/pregame_setup.php", :body => params.merge(common_params), :headers => {
       "Authorization" => token
     })
   end

--- a/auth.rb
+++ b/auth.rb
@@ -9,7 +9,7 @@ class EmailAuth
     {
       :g => 1,
       :auth_version => "2.0.0",
-      :client_version => "3.0.5",
+      :client_version => "4.5.0",
       :device_id => $settings.device_id,
       :device_model => $settings.device_model,
       :device_vendor => $settings.device_vendor,

--- a/config.yml.example
+++ b/config.yml.example
@@ -5,3 +5,4 @@
 :device_vendor: Sony
 :os_version: 9
 :lang: en
+:access_key: cd7eacf6-9d44-4584-8a85-0d53c69e4b4c ( This is for version 4.5.0, this is hardcoded into the game and will change every update )

--- a/config.yml.example
+++ b/config.yml.example
@@ -5,4 +5,4 @@
 :device_vendor: Sony
 :os_version: 9
 :lang: en
-:access_key: cd7eacf6-9d44-4584-8a85-0d53c69e4b4c ( This is for version 4.5.0, this is hardcoded into the game and will change every update )
+:access_key: dd4296c9-a48d-4645-9e7e-9cc63be453c6 (4.5.2, hardcoded and changes every update)


### PR DESCRIPTION
As of new updates a hard coded access key is required to use the pregame setup api, this commit should update this tool to 4.5.0.